### PR TITLE
Fix SELinux contexts

### DIFF
--- a/common/post-fs-data.sh
+++ b/common/post-fs-data.sh
@@ -14,3 +14,4 @@ MODDIR=${0%/*}
 
 mv -f /data/misc/user/0/cacerts-added/* $MODDIR/system/etc/security/cacerts
 chown 0:0 $MODDIR/system/etc/security/cacerts/*
+chcon u:object_r:system_file:s0 $MODDIR/system/etc/security/cacerts/*


### PR DESCRIPTION
If SELinux is enforcing and a cert's context is not
`u:object_r:system_file:s0`, Android Pie will reject it.