### PR TITLE
Fix SELinux context for certificate.

### DIFF
--- a/common/post-fs-data.sh
+++ b/common/post-fs-data.sh
@@ -14,4 +14,4 @@ MODDIR=${0%/*}
 
 mv -f /data/misc/user/0/cacerts-added/* $MODDIR/system/etc/security/cacerts
 chown 0:0 $MODDIR/system/etc/security/cacerts/*
-chcon u:object_r:system_file:s0 $MODDIR/system/etc/security/cacerts/*
+chcon u:object_r:system_security_cacerts_file:s0 $MODDIR/system/etc/security/cacerts/*


### PR DESCRIPTION
On Android 10 at least, the proper SELinux context is u:object_r:system_security_cacerts_file:s0.

This is the case on the Note10+, the Tab S6 and the Fold, for example.