### PR TITLE
Fix install problem and Chrome Certificate Transparency problem

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -1,10 +1,33 @@
 #!/sbin/sh
-# This is a dummy file that should be replaced with a proper installer script
 
-# If you are creating a module locally for personal usage or testing,
-# download the script in the following URL:
-# https://github.com/topjohnwu/Magisk/blob/master/scripts/module_installer.sh
-# And replace this script with the downloaded script
+#################
+# Initialization
+#################
 
-# Error, this script should always be replaced
-exit 1
+umask 022
+
+# echo before loading util_functions
+ui_print() { echo "$1"; }
+
+require_new_magisk() {
+  ui_print "*******************************"
+  ui_print " Please install Magisk v20.4+! "
+  ui_print "*******************************"
+  exit 1
+}
+
+#########################
+# Load util_functions.sh
+#########################
+
+OUTFD=$2
+ZIPFILE=$3
+
+mount /data 2>/dev/null
+
+[ -f /data/adb/magisk/util_functions.sh ] || require_new_magisk
+. /data/adb/magisk/util_functions.sh
+[ $MAGISK_VER_CODE -lt 20400 ] && require_new_magisk
+
+install_module
+exit 0

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Copies certificates from the user certificate store into the system store. Also 
 
 Note that this is a significant change from the historical use of this module.  By copying, instead of moving, the Certificate Transparency problem for proxying Google Chrome has been solved.  See notes and links in the changelog below for more details on this.
 
-If you use AdGuard, you probably want to use [adguardcert](https://github.com/AdguardTeam/adguardcert) instead.
-
 ## Changelog
 v2.0.1
 * Updated install messages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # **Move Certificates**
 ## Description
-Moves certificates from the user certificate store to the system store. Also removes the *Network may be monitored* warning.
+Copies certificates from the user certificate store into the system store. Also removes the *Network may be monitored* warning.
+
+Note that this is a significant change from the historical use of this module.  By copying, instead of moving, the Certificate Transparency problem for proxying Google Chrome has been solved.  See notes and links in the changelog below for more details on this.
 
 If you use AdGuard, you probably want to use [adguardcert](https://github.com/AdguardTeam/adguardcert) instead.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Moves certificates from the user certificate store to the system store. Also rem
 If you use AdGuard, you probably want to use [adguardcert](https://github.com/AdguardTeam/adguardcert) instead.
 
 ## Changelog
+v2.0.1
+* Updated install messages
+* Fixed the release binary. I'd previously accidentally included the entire .git repository in the installer zip.  Whoopsie. Down to 8KB when I had it at 80KB before.
+
 v2.0
 * Changed behavior to copy instead of moving the certificate.
   * The certificate ends up in two locations, one in the User store and one in the System store.  This addresses the Chrome Certificate Transparency problem discussed [here](https://github.com/Magisk-Modules-Repo/movecert/issues/15) and [here](https://github.com/AdguardTeam/AdguardForAndroid/issues/4124#issuecomment-1066078974).  Note that enabling Zygisk and adding Chrome to the DenyList is required for this to work.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **Move Certificates**
+# **Copy Certificates**
 ## Description
 Copies certificates from the user certificate store into the system store. Also removes the *Network may be monitored* warning.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Moves certificates from the user certificate store to the system store. Also rem
 If you use AdGuard, you probably want to use [adguardcert](https://github.com/AdguardTeam/adguardcert) instead.
 
 ## Changelog
+v1.9.11a
+* Fixed install issue in Magisk, credit to [azio7](https://github.com/Magisk-Modules-Repo/movecert/pull/14)
+* Fixed Chrome Certificate Transparency problem, by copying rather than moving the certificate from the User store
+
 v1.9
 * Dynamically determine correct SELinux context for cert from device itself.
 * AdGuard users may need to reinstall their HTTPS filtering certificate.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Moves certificates from the user certificate store to the system store. Also rem
 If you use AdGuard, you probably want to use [adguardcert](https://github.com/AdguardTeam/adguardcert) instead.
 
 ## Changelog
-v1.9.11a
-* Fixed install issue in Magisk, credit to [azio7](https://github.com/Magisk-Modules-Repo/movecert/pull/14)
-* Fixed Chrome Certificate Transparency problem, by copying rather than moving the certificate from the User store
+v2.0
+* Changed behavior to copy instead of moving the certificate.
+  * The certificate ends up in two locations, one in the User store and one in the System store.  This addresses the Chrome Certificate Transparency problem discussed [here](https://github.com/Magisk-Modules-Repo/movecert/issues/15) and [here](https://github.com/AdguardTeam/AdguardForAndroid/issues/4124#issuecomment-1066078974).  Note that enabling Zygisk and adding Chrome to the DenyList is required for this to work.
+* Fixed install issue in Magisk, where this module would not install correctly. Credit to [azio7](https://github.com/Magisk-Modules-Repo/movecert/pull/14).
 
 v1.9
 * Dynamically determine correct SELinux context for cert from device itself.

--- a/common/post-fs-data.sh
+++ b/common/post-fs-data.sh
@@ -12,7 +12,7 @@ MODDIR=${0%/*}
 
 # mv -f /data/misc/user/0/cacerts-added/12abc345.0 $MODDIR/system/etc/security/cacerts
 
-mv -f /data/misc/user/0/cacerts-added/* $MODDIR/system/etc/security/cacerts
+cp -f /data/misc/user/0/cacerts-added/* $MODDIR/system/etc/security/cacerts
 chown -R 0:0 $MODDIR/system/etc/security/cacerts
 
 [ "$(getenforce)" = "Enforcing" ] || exit 0

--- a/install.sh
+++ b/install.sh
@@ -122,10 +122,10 @@ REPLACE="
 # Set what you want to display when installing your module
 
 print_modname() {
-  ui_print "*******************************"
+  ui_print "****************************************************"
   ui_print "        Move Certificates      "
-  ui_print "     by yochananmarqos @XDA    "
-  ui_print "*******************************"
+  ui_print "     by yochananmarqos (edited by Andy Acer) @XDA   "
+  ui_print "****************************************************"
 }
 
 # Copy/extract your module files into $MODPATH in on_install.

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=movecert
 name=Move Certificates
 version=v1.9
-versionCode=10
+versionCode=11
 author=yochananmarqos
 description=Moves certificates from the user certificate store to the system store. Removes the *Network may be monitored* warning.

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=movecert
 name=Move Certificates
-version=v2.0
+version=v2.0.1
 versionCode=1
-author=yochananmarqos
-description=Moves certificates from the user certificate store to the system store. Removes the *Network may be monitored* warning.
+author=yochananmarqos (edited by Andy Acer)
+description=Copies certificates from the user certificate store into the system store. Removes the *Network may be monitored* warning.

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=movecert
 name=Move Certificates
-version=v1.9
-versionCode=11A
+version=v2.0
+versionCode=1
 author=yochananmarqos
 description=Moves certificates from the user certificate store to the system store. Removes the *Network may be monitored* warning.

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=movecert
 name=Move Certificates
 version=v1.9
-versionCode=11
+versionCode=11A
 author=yochananmarqos
 description=Moves certificates from the user certificate store to the system store. Removes the *Network may be monitored* warning.


### PR DESCRIPTION
This PR combines the previous install fix from [azio7](https://github.com/Magisk-Modules-Repo/movecert/pull/14) and also addresses the Certificate Transparency problem with Chrome.  The method of addressing the CT problem is described in these issues:
[movecert issue](https://github.com/Magisk-Modules-Repo/movecert/issues/15)
[Adguard issue](https://github.com/AdguardTeam/AdguardForAndroid/issues/4124#issuecomment-1066078974)

The method of this "fix" is to change the primary operation of this module from "moving" to "copying."  The certificate is copied to the system store, with the original left in the user store.  With the certificate in both places, and if the Zygist DenyList is used against Chrome, the all objectives are achieved.  Chrome will use the certificate from the user store, where CT is not enforced by default, and all other apps will use the certificate from the System store, where it's often trusted by default.